### PR TITLE
Update draper dependency in gemspec to 3.0.0.pre1

### DIFF
--- a/draper_simple_form.gemspec
+++ b/draper_simple_form.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "draper", "~> 1.0"
+  spec.add_dependency "draper", "~> 3.0.0.pre1"
   spec.add_dependency "simple_form"
 end


### PR DESCRIPTION
Update draper dependency to 3.0.0.pre1 for rails 5 compatibility